### PR TITLE
Clearing model attributes after destroying parent record

### DIFF
--- a/lib/redis_model/attribute.rb
+++ b/lib/redis_model/attribute.rb
@@ -119,6 +119,21 @@ module RedisModel
 
     def self.included(klass)
       klass.extend ClassMethods
+
+      if klass.respond_to?(:after_destroy)
+        klass.after_destroy :clear_redis_model_attributes
+      end
+    end
+
+    # Public: Clears attributes defined by RedisModel.
+    #
+    # Returns nothing.
+    def clear_redis_model_attributes
+      RedisModel::Schema.collection.each do |klass, _|
+        if klass < RedisModel::BelongedTo && Object.const_get(klass.to_s.deconstantize) >= self.class
+          self.send(klass.to_s.demodulize.underscore).del
+        end
+      end
     end
   end
 end

--- a/redis_model.gemspec
+++ b/redis_model.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'kaminari'
+  spec.add_development_dependency 'activerecord'
+  spec.add_development_dependency 'sqlite3'
 end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -1,0 +1,5 @@
+require 'active_record'
+
+ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
+ActiveRecord::Migration.verbose = false
+require File.join(File.dirname(__FILE__), 'schema')

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -1,0 +1,5 @@
+ActiveRecord::Schema.define(version: 20150101000000) do
+  create_table "ar_model", force: true do |t|
+    t.string 'foo'
+  end
+end


### PR DESCRIPTION
Added support to clear attributes set via `redis_model_attribute` after destroying the parent record.
